### PR TITLE
fix: Text color not change in dark mode 

### DIFF
--- a/src/templates/back_template.html
+++ b/src/templates/back_template.html
@@ -15,7 +15,6 @@
     .text {
         font-family: arial;
         font-size: 18px;
-        color: black;
     }
 
     .breadcrumb2 {

--- a/src/templates/front_template.html
+++ b/src/templates/front_template.html
@@ -12,7 +12,6 @@
     .text {
         font-family: arial;
         font-size: 18px;
-        color: black;
     }
 
     .breadcrumb2 {


### PR DESCRIPTION
As title.
![image](https://user-images.githubusercontent.com/34705216/178758521-c926d47f-a94c-4011-ab4b-9aacec7f8fbc.png)


This PR removes the explicit text color in front & back template.html to fix this issue.